### PR TITLE
Fix #28

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       environment:
         RETHINKDB_PORT_28015_TCP_ADDR: rethinkdb
         REDIS_PORT_6379_TCP_ADDR: redis
-
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
    api:
       image: dolaterio/dolaterio
       depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,38 @@
-worker:
-  image: dolaterio/dolaterio
-  links:
-    - "redis"
-    - "rethinkdb"
-  command: /worker
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
+version: '2'
+services:
+   worker:
+      image: dolaterio/dolaterio
+      depends_on:
+        - rethinkdb
+        - redis
+        - migrate
+      command: /worker
+      environment:
+        RETHINKDB_PORT_28015_TCP_ADDR: rethinkdb
+        REDIS_PORT_6379_TCP_ADDR: redis
 
-api:
-  image: dolaterio/dolaterio
-  links:
-    - "redis"
-    - "rethinkdb"
-  command: /api
-  ports:
-    - "7000:7000"
-  environment:
-    - BINDING=0.0.0.0
-
-redis:
-  image: redis:2.8
-
-rethinkdb:
-  image: rethinkdb:2.0
+   api:
+      image: dolaterio/dolaterio
+      depends_on:
+        - rethinkdb
+        - redis
+        - migrate
+      command: /api
+      ports:
+        - "7000:7000"
+      environment:
+        BINDING: 0.0.0.0
+        RETHINKDB_PORT_28015_TCP_ADDR: rethinkdb
+        REDIS_PORT_6379_TCP_ADDR: redis
+   migrate:
+      image: dolaterio/dolaterio
+      environment:
+        RETHINKDB_PORT_28015_TCP_ADDR: rethinkdb
+      depends_on:
+        - rethinkdb
+        - redis
+      command: /migrate
+   redis:
+      image: redis:2.8
+   rethinkdb:
+      image: rethinkdb:2.0


### PR DESCRIPTION
Fixes #28

## Documentation : 

- To connect docker containers running dolaterio images are needed to be connected to the rethinkdb and redis containers via ENV variables `RETHINKDB_PORT_28015_TCP_ADDR` & `REDIS_PORT_6379_TCP_ADDR`. Added these variables with right values.
- Updated `docker-compose.yml` to `Version 2` format of compose so that users do not run into issues.